### PR TITLE
修复账号绑定相关的bug

### DIFF
--- a/components/Auth/login.vue
+++ b/components/Auth/login.vue
@@ -27,9 +27,6 @@
       <h1 class="oauth-title">
         {{ $t('auth.otherAccount') }}
       </h1>
-      <p class="warning-tip">
-        {{ $t('auth.loginWarning') }}
-      </p>
       <div class="oauth">
         <el-tooltip :content="$t('auth.vntTitle')" class="item" effect="dark" placement="top">
           <div @click="walletLogin('Vnt')" class="oauth-bg bg-blue1">

--- a/pages/_lang/setting/account.vue
+++ b/pages/_lang/setting/account.vue
@@ -176,7 +176,7 @@ export default {
               window.location.reload()
             }, 300)
           } else {
-            this.$message.success(res.message + '123')
+            this.$message.success(res.message)
             this.getAccountList()
           }
         } else {

--- a/pages/_lang/setting/account.vue
+++ b/pages/_lang/setting/account.vue
@@ -3,6 +3,8 @@
     <template slot="main">
       <userNav nav-list-url="setting" />
       <div class="list">
+        <p>瞬Matataki支持绑定尚未注册的账号，账号解绑后可再次被绑定。</p>
+        <p>已绑定的任意账号均可用于登录</p>
         <div
           v-for="(item, idx) in accountList"
           :key="idx"
@@ -174,7 +176,7 @@ export default {
               window.location.reload()
             }, 300)
           } else {
-            this.$message.success(res.message)
+            this.$message.success(res.message + '123')
             this.getAccountList()
           }
         } else {
@@ -384,7 +386,7 @@ export default {
     },
     accountChangeFunc(label, idx) {
       if (!this.isLogined) return this.$store.commit('setLoginModal', true)
-      if (!this.accountList[idx].status) return this.$message.warning('请先绑定账号')
+      if (!this.accountList[idx].status) return this.$message.warning('绑定后才可设置为主账号')
       if (label === 'email') {
         this.$prompt('请输入邮箱密码', '提示', {
           confirmButtonText: '确定',


### PR DESCRIPTION
去掉在登录面板上的文字 “不同账号之间内容不互通”
在账号管理页面中增加固定文字显示
设置主账号失败的提示文字为：“绑定后才可设置为主账号”