### PR TITLE
修复文章列表 model 更新时标题无法更新

### DIFF
--- a/components/article_card_list/index.vue
+++ b/components/article_card_list/index.vue
@@ -32,7 +32,7 @@
             </div>
           </div>
           <div class="article-title">
-            <h3 v-clampy="2" v-html="xssTitle" class="search-res" />
+            <h3 v-html="xssTitle" class="search-res" />
           </div>
           <div class="des">
             <!-- 文章卡阅读和投资 -->
@@ -209,6 +209,10 @@ export default {
       cursor: pointer;
       margin: 0;
       padding: 0;
+
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
     }
   }
 }


### PR DESCRIPTION
初步看 vue-clampy 在 xssTitle 更新时 keep 住旧的 dom element 导致 model 更新后还是用旧的，于是整个列表的标题没有更新

无奈这里使用纯 CSS 方式解决（多行文本的省略实现还在草案中，但目前主流的浏览器都有支持）