### PR TITLE
:pencil2:让非当前年份评论显示年份

### DIFF
--- a/components/comment/article_card.vue
+++ b/components/comment/article_card.vue
@@ -8,7 +8,7 @@
       >
         <c-user-popover :user-id="Number(comment.uid)">
           <c-avatar
-            :src="avatar" 
+            :src="avatar"
             :recommend-author="comment.user_is_recommend === 1"
             :token-user="comment.user_is_token === 1"
           />
@@ -80,6 +80,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import replyInput from './ReplyInput'
+import {isNDaysAgo} from '~/utils/momentFun'
 
 export default {
   name: 'CommentCard',
@@ -105,7 +106,16 @@ export default {
     },
     friendlyDate() {
       const time = this.moment(this.comment.create_time)
-      return time.format('MMMDo HH:mm')
+      // 如果评论是不是今年的，就显示年份
+      if (!isNDaysAgo(2, time)) {
+        return time.fromNow()
+      } else {
+        if (time.format('YYYY') !== this.moment(new Date()).format('YYYY')) {
+          return time.format('YYYY年MMMDo HH:mm') // TODO i18n
+        } else {
+          return time.format('MMMDo HH:mm')
+        }
+      }
     },
     avatar() {
       if (this.comment.avatar) return this.$ossProcess(this.comment.avatar)


### PR DESCRIPTION
<img width="297" alt="6A66464B-0A6D-4002-8165-F6B537E73E26" src="https://user-images.githubusercontent.com/17664845/108614142-31a54180-7433-11eb-9f48-69e568e952e9.png">
现在的评论是这个样子，但是在英文环境下的年份依然会显示成xxxx年，所以加了个TODO