### PR TITLE
修复exchange交易所选择fan票时层级错乱的问题

### DIFF
--- a/components/exchange/TokenList.vue
+++ b/components/exchange/TokenList.vue
@@ -1,5 +1,6 @@
 <template>
   <el-dialog
+    :modal-append-to-body="false"
     :close-on-click-modal="false"
     :visible.sync="showModal"
     :lock-scroll="false"

--- a/pages/exchange/index.vue
+++ b/pages/exchange/index.vue
@@ -129,6 +129,7 @@ export default {
     flex-flow: row nowrap;
     border-radius: 3rem;
     width: 400px;
+    z-index: 0;
   }
   .el-tabs__nav-scroll {
     display: flex;


### PR DESCRIPTION
修复前
<img width="660" alt="QQ20210224-211602@2x" src="https://user-images.githubusercontent.com/17664845/109006179-c1721680-76e5-11eb-90a1-41a04a0a7f56.png">
修复后
<img width="647" alt="QQ20210224-211615@2x" src="https://user-images.githubusercontent.com/17664845/109006210-c931bb00-76e5-11eb-939f-3d9cf8087c3e.png">
