### PR TITLE
修复dapp页面中当卡片描述文字过长时会溢出的问题

### DIFF
--- a/components/dapp/dapp_item.vue
+++ b/components/dapp/dapp_item.vue
@@ -57,7 +57,6 @@ export default {
   background: rgba(255, 255, 255, 1);
   border-radius: 10px;
   float: left;
-  padding: 0 20px 20px;
   box-sizing: border-box;
   text-align: center;
   transition: all 0.3s;


### PR DESCRIPTION
关联 #1119 
修复后的效果
<img width="365" alt="QQ20210302-115756@2x" src="https://user-images.githubusercontent.com/17664845/109594963-96a51980-7b4e-11eb-8cb9-248f2ea4c7b9.png">