### PR TITLE
对dapp页面轮播图进行移动端适配

### DIFF
--- a/components/dapp/dapp_banner.vue
+++ b/components/dapp/dapp_banner.vue
@@ -3,6 +3,7 @@
     trigger="click"
     height="240px"
     class="swipe-dapp"
+    interval="100000"
   >
     <el-carousel-item>
       <div class="dapp-head-governance">
@@ -114,11 +115,10 @@ export default {
     margin: 8px 0 0 0;
   }
   .head-text {
-    margin: 0 0 0 190px;
+    margin: 0 auto 0 auto;
     text-align: left;
   }
   .head-btn {
-    // background: #542de0;
     font-size: 16px;
     font-weight: 500;
     line-height: 22px;
@@ -204,7 +204,7 @@ export default {
     margin: 0;
   }
   .head-text {
-    margin: 0 0 0 180px;
+    margin: 0 auto 0 auto;
     img {
       display: block;
       width: 464px;
@@ -410,16 +410,6 @@ export default {
   .dapp-head .computer {
     margin-right: 60px;
   }
-
-  // .dapp-container .item li {
-  //   width: calc(33.33% - 13.33333px);
-  //   &:nth-of-type(3n) {
-  //     margin-right: 0;
-  //   }
-  //   &:nth-of-type(4n) {
-  //     margin-right: 20px;
-  //   }
-  // }
 }
 
 
@@ -436,18 +426,32 @@ export default {
       text-align: center;
     }
   }
-
-  // .dapp-container .item li {
-  //   width: calc(50% - 10px);
-  //   &:nth-of-type(2n) {
-  //     margin-right: 0;
-  //   }
-  //   &:nth-of-type(3n) {
-  //     margin-right: 20px;
-  //   }
-  // }
 }
 
+@media screen and (max-width: 600px) {
+  .dapp-head-governance {
+    .head-text {
+      text-align: center;
+    }
+    .head-logo {
+      width: 300px;
+    }
+    .head-description {
+      font-size: 12px;
+    }
+  }
+  .dapp-head-quest {
+    .head-text {
+      text-align: center;
+      img {
+        width: 300px;
+      }
+    }
+    .head-description {
+      margin: 0 auto 0 auto;
+    }
+  }
+}
 
 @media screen and (max-width: 540px) {
   .dapp-head {
@@ -460,6 +464,16 @@ export default {
     }
     .head-btn {
       font-size: 14px;
+    }
+  }
+}
+</style>
+
+<style lang="less">
+@media screen and (max-width: 600px){
+  .swipe-dapp {
+    .el-carousel__button {
+      width: 15px;
     }
   }
 }

--- a/components/dapp/dapp_banner.vue
+++ b/components/dapp/dapp_banner.vue
@@ -3,7 +3,6 @@
     trigger="click"
     height="240px"
     class="swipe-dapp"
-    interval="100000"
   >
     <el-carousel-item>
       <div class="dapp-head-governance">

--- a/components/platform_status/twitter_card/twitter_card_unit.vue
+++ b/components/platform_status/twitter_card/twitter_card_unit.vue
@@ -386,6 +386,7 @@ span {
       display: flex;
       margin: 10px 0 10px;
       .flow-default {
+        color: #657786;
         flex: 1;
         svg {
           height: 18px;
@@ -393,7 +394,7 @@ span {
           color: #657786;
         }
         span {
-          margin:  0 0 0 5px;
+          margin:  0 0 0 3px;
         }
       }
       &-comment {


### PR DESCRIPTION
关联 #1108 #1102
效果：
<img width="558" alt="QQ20210302-135241@2x" src="https://user-images.githubusercontent.com/17664845/109604527-a2004100-7b5e-11eb-92cb-77fc808666d2.png">
<img width="557" alt="QQ20210302-135254@2x" src="https://user-images.githubusercontent.com/17664845/109604532-a4629b00-7b5e-11eb-8346-26b89fa6a45d.png">
